### PR TITLE
fix: add missing .env.old.example

### DIFF
--- a/.env.old.example
+++ b/.env.old.example
@@ -1,0 +1,19 @@
+# ==========================================
+# our-home-app environment variables (legacy example)
+# ==========================================
+
+# Prisma / Database
+# Local development default used by scripts:
+#   file:./prisma/dev.db
+DATABASE_URL="file:./prisma/dev.db"
+
+# App server port (Vite + API middleware)
+PORT=5174
+
+# Runtime environment
+# Use "development" locally and "production" in deploy.
+NODE_ENV="development"
+
+# Auth cookie/session signing secret
+# IMPORTANT: change this in production.
+AUTH_SESSION_SECRET="dev-auth-session-secret-change-me"


### PR DESCRIPTION
Closes #3

## Summary
- Added missing `.env.old.example` file
- Included all environment variables currently used by the app:
  - `DATABASE_URL`
  - `PORT`
  - `NODE_ENV`
  - `AUTH_SESSION_SECRET`
- Added safe development defaults and production notes for each variable

## Why
Issue #3 requested a legacy example env file containing the required env vars for project setup.