### PR TITLE
feat: implement Metas v1.1 (type + targetDate)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,13 @@ enum ScheduleSourceType {
   RECURRING
 }
 
+enum GoalType {
+  FINANCIAL
+  PERSONAL
+  FAMILY
+  DREAM
+}
+
 model Account {
   id             String        @id @default(cuid())
   householdId    String
@@ -163,6 +170,22 @@ model ScheduledInstance {
   creditCard CreditCard? @relation(fields: [creditCardId], references: [id])
 
   @@index([householdId, monthKey])
+}
+
+
+model Goal {
+  id          String    @id @default(cuid())
+  householdId String
+  title       String
+  description String
+  type        GoalType
+  targetDate  DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@index([householdId, createdAt])
+  @@index([householdId, type])
+  @@index([householdId, targetDate])
 }
 
 model Household {

--- a/prisma/schema.prod.prisma
+++ b/prisma/schema.prod.prisma
@@ -27,6 +27,13 @@ enum ScheduleSourceType {
   RECURRING
 }
 
+enum GoalType {
+  FINANCIAL
+  PERSONAL
+  FAMILY
+  DREAM
+}
+
 model Account {
   id             String        @id @default(cuid())
   householdId    String
@@ -163,6 +170,22 @@ model ScheduledInstance {
   creditCard CreditCard? @relation(fields: [creditCardId], references: [id])
 
   @@index([householdId, monthKey])
+}
+
+
+model Goal {
+  id          String    @id @default(cuid())
+  householdId String
+  title       String
+  description String
+  type        GoalType
+  targetDate  DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@index([householdId, createdAt])
+  @@index([householdId, type])
+  @@index([householdId, targetDate])
 }
 
 model Household {

--- a/src/app/foundation/goals/page.tsx
+++ b/src/app/foundation/goals/page.tsx
@@ -1,0 +1,141 @@
+import { useMemo, useState } from "react";
+
+import { GoalForm, goalTypeLabel, type GoalType } from "../../../components/foundation/goal-form";
+import { Badge } from "../../../components/ui/badge";
+import { Button } from "../../../components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../../../components/ui/card";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "../../../components/ui/sheet";
+import { useSnackbar } from "../../../components/ui/snackbar";
+import { getRuntimeHouseholdId, goalsController } from "../runtime";
+
+function formatDate(value: string | null) {
+  if (!value) return "Sem data alvo";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Sem data alvo";
+  return date.toLocaleDateString("pt-BR", { timeZone: "UTC" });
+}
+
+export default function GoalsPage() {
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [editModalOpen, setEditModalOpen] = useState(false);
+  const [editingGoalId, setEditingGoalId] = useState<string | null>(null);
+  const { notify } = useSnackbar();
+  const householdId = getRuntimeHouseholdId();
+  const goals = useMemo(() => goalsController.listGoals(householdId), [refreshKey, householdId]);
+  const editingGoal = useMemo(() => goals.find((item) => item.id === editingGoalId) ?? null, [editingGoalId, goals]);
+
+  return (
+    <main className="space-y-4">
+      <section className="section-reveal flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100">Metas</h2>
+          <p className="text-sm text-slate-500 dark:text-slate-300">Mapeie objetivos financeiros, pessoais e da familia.</p>
+        </div>
+        <Button type="button" onClick={() => setCreateModalOpen(true)}>
+          Nova meta
+        </Button>
+      </section>
+
+      <Card className="section-reveal">
+        <CardHeader>
+          <CardTitle>Metas cadastradas</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {goals.length === 0 ? <p className="text-sm text-slate-500 dark:text-slate-300">Nenhuma meta cadastrada ainda.</p> : null}
+          <ul className="space-y-3">
+            {goals.map((goal) => (
+              <li key={goal.id} className="space-y-2 rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-slate-800 dark:bg-slate-950/70">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="font-semibold text-slate-900 dark:text-slate-100">{goal.title}</p>
+                    <p className="text-sm text-slate-600 dark:text-slate-300">{goal.description}</p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      setEditingGoalId(goal.id);
+                      setEditModalOpen(true);
+                    }}
+                  >
+                    Editar
+                  </Button>
+                </div>
+                <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-300">
+                  <Badge variant="secondary">{goalTypeLabel(goal.type as GoalType)}</Badge>
+                  <span>{formatDate(goal.targetDate)}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+
+      <Sheet open={createModalOpen} onOpenChange={setCreateModalOpen}>
+        <SheetContent className="inset-y-auto left-1/2 top-1/2 h-auto max-h-[88vh] w-[94%] max-w-xl -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-3xl border-r-0">
+          <SheetHeader>
+            <SheetTitle>Nova meta</SheetTitle>
+            <SheetDescription>Cadastre titulo, descricao, tipo e data alvo.</SheetDescription>
+          </SheetHeader>
+          <div className="mt-4">
+            <GoalForm
+              submitLabel="Salvar meta"
+              onSubmit={(values) => {
+                try {
+                  goalsController.createGoal({ householdId, ...values });
+                  setRefreshKey((prev) => prev + 1);
+                  setCreateModalOpen(false);
+                  notify({ message: "Meta cadastrada com sucesso.", tone: "success" });
+                } catch {
+                  notify({ message: "Nao foi possivel cadastrar a meta.", tone: "error" });
+                }
+              }}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <Sheet
+        open={editModalOpen}
+        onOpenChange={(open) => {
+          setEditModalOpen(open);
+          if (!open) {
+            setEditingGoalId(null);
+          }
+        }}
+      >
+        <SheetContent className="inset-y-auto left-1/2 top-1/2 h-auto max-h-[88vh] w-[94%] max-w-xl -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-3xl border-r-0">
+          <SheetHeader>
+            <SheetTitle>Editar meta</SheetTitle>
+            <SheetDescription>Atualize as informacoes da meta.</SheetDescription>
+          </SheetHeader>
+          <div className="mt-4">
+            {editingGoal ? (
+              <GoalForm
+                submitLabel="Salvar alteracoes"
+                initialValues={{
+                  title: editingGoal.title,
+                  description: editingGoal.description,
+                  type: editingGoal.type,
+                  targetDate: editingGoal.targetDate ? editingGoal.targetDate.slice(0, 10) : "",
+                }}
+                onSubmit={(values) => {
+                  try {
+                    goalsController.updateGoal({ householdId, id: editingGoal.id, ...values });
+                    setRefreshKey((prev) => prev + 1);
+                    setEditModalOpen(false);
+                    setEditingGoalId(null);
+                    notify({ message: "Meta atualizada com sucesso.", tone: "success" });
+                  } catch {
+                    notify({ message: "Nao foi possivel atualizar a meta.", tone: "error" });
+                  }
+                }}
+              />
+            ) : null}
+          </div>
+        </SheetContent>
+      </Sheet>
+    </main>
+  );
+}

--- a/src/app/foundation/runtime.ts
+++ b/src/app/foundation/runtime.ts
@@ -29,6 +29,51 @@ type MethodReturn<T> = T extends (...args: any[]) => infer R ? R : never;
 type AccountsControllerContract = Pick<AccountsController, "createAccount" | "updateAccountGoal" | "listAccounts" | "getConsolidatedBalance">;
 type CardsControllerContract = Pick<CardsController, "createCard" | "listCards" | "updateCard" | "deleteCard">;
 type CategoriesControllerContract = Pick<CategoriesController, "createCategory" | "listCategories">;
+type GoalsControllerContract = {
+  createGoal: (input: {
+    householdId: string;
+    title: string;
+    description: string;
+    type: "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM";
+    targetDate?: string | null;
+  }) => {
+    id: string;
+    householdId: string;
+    title: string;
+    description: string;
+    type: "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM";
+    targetDate: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+  listGoals: (householdId: string) => Array<{
+    id: string;
+    householdId: string;
+    title: string;
+    description: string;
+    type: "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM";
+    targetDate: string | null;
+    createdAt: string;
+    updatedAt: string;
+  }>;
+  updateGoal: (input: {
+    householdId: string;
+    id: string;
+    title: string;
+    description: string;
+    type: "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM";
+    targetDate?: string | null;
+  }) => {
+    id: string;
+    householdId: string;
+    title: string;
+    description: string;
+    type: "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM";
+    targetDate: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+};
 type TransactionsControllerContract = Pick<
   TransactionsController,
   | "createTransaction"
@@ -69,6 +114,7 @@ type Runtime = {
   accountsController: AccountsControllerContract;
   cardsController: CardsControllerContract;
   categoriesController: CategoriesControllerContract;
+  goalsController: GoalsControllerContract;
   transactionsController: TransactionsControllerContract;
   invoicesController: InvoicesControllerContract;
   freeBalanceController: FreeBalanceControllerContract;
@@ -167,6 +213,17 @@ function createLocalRuntime(): Runtime {
     ),
   );
 
+  const localGoalsStore: Array<{
+    id: string;
+    householdId: string;
+    title: string;
+    description: string;
+    type: "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM";
+    targetDate: string | null;
+    createdAt: string;
+    updatedAt: string;
+  }> = [];
+
   return {
     accountsController,
     cardsController: {
@@ -186,6 +243,39 @@ function createLocalRuntime(): Runtime {
       },
     },
     categoriesController,
+    goalsController: {
+      createGoal: (input) => {
+        const now = new Date().toISOString();
+        const record = {
+          id: `goal-${Date.now()}`,
+          householdId: input.householdId,
+          title: input.title,
+          description: input.description,
+          type: input.type,
+          targetDate: input.targetDate ?? null,
+          createdAt: now,
+          updatedAt: now,
+        };
+        localGoalsStore.push(record);
+        return record;
+      },
+      listGoals: (householdId) =>
+        localGoalsStore
+          .filter((item) => item.householdId === householdId)
+          .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1)),
+      updateGoal: (input) => {
+        const found = localGoalsStore.find((item) => item.id === input.id && item.householdId === input.householdId);
+        if (!found) {
+          throw new Error("GOAL_NOT_FOUND");
+        }
+        found.title = input.title;
+        found.description = input.description;
+        found.type = input.type;
+        found.targetDate = input.targetDate ?? null;
+        found.updatedAt = new Date().toISOString();
+        return found;
+      },
+    },
     transactionsController,
     invoicesController,
     freeBalanceController,
@@ -212,6 +302,12 @@ function createApiRuntime(): Runtime {
   type CategoriesCreateInput = MethodArgs<Runtime["categoriesController"]["createCategory"]>[0];
   type CategoriesCreateOutput = MethodReturn<Runtime["categoriesController"]["createCategory"]>;
   type CategoriesListOutput = MethodReturn<Runtime["categoriesController"]["listCategories"]>;
+
+  type GoalsCreateInput = MethodArgs<Runtime["goalsController"]["createGoal"]>[0];
+  type GoalsCreateOutput = MethodReturn<Runtime["goalsController"]["createGoal"]>;
+  type GoalsListOutput = MethodReturn<Runtime["goalsController"]["listGoals"]>;
+  type GoalsUpdateInput = MethodArgs<Runtime["goalsController"]["updateGoal"]>[0];
+  type GoalsUpdateOutput = MethodReturn<Runtime["goalsController"]["updateGoal"]>;
 
   type TransactionsCreateInput = MethodArgs<Runtime["transactionsController"]["createTransaction"]>[0];
   type TransactionsCreateOutput = MethodReturn<Runtime["transactionsController"]["createTransaction"]>;
@@ -313,6 +409,24 @@ function createApiRuntime(): Runtime {
         requestSync<CategoriesCreateOutput>("POST", "/api/categories", { name: input.name }),
       listCategories: (_householdId: string): CategoriesListOutput =>
         requestSync<CategoriesListOutput>("GET", "/api/categories"),
+    },
+    goalsController: {
+      createGoal: (input: GoalsCreateInput): GoalsCreateOutput =>
+        requestSync<GoalsCreateOutput>("POST", "/api/goals", {
+          title: input.title,
+          description: input.description,
+          type: input.type,
+          targetDate: input.targetDate ?? null,
+        }),
+      listGoals: (_householdId: string): GoalsListOutput => requestSync<GoalsListOutput>("GET", "/api/goals"),
+      updateGoal: (input: GoalsUpdateInput): GoalsUpdateOutput =>
+        requestSync<GoalsUpdateOutput>("POST", "/api/goals/edit", {
+          id: input.id,
+          title: input.title,
+          description: input.description,
+          type: input.type,
+          targetDate: input.targetDate ?? null,
+        }),
     },
     transactionsController: {
       createTransaction: (input: TransactionsCreateInput): TransactionsCreateOutput =>
@@ -457,6 +571,7 @@ const runtime = createRuntime();
 export const accountsController = runtime.accountsController;
 export const cardsController = runtime.cardsController;
 export const categoriesController = runtime.categoriesController;
+export const goalsController = runtime.goalsController;
 export const transactionsController = runtime.transactionsController;
 export const invoicesController = runtime.invoicesController;
 export const freeBalanceController = runtime.freeBalanceController;

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,13 +1,14 @@
 import React from "react";
-import { CreditCard, Grid2X2, LayoutList, Wallet } from "lucide-react";
+import { CreditCard, Grid2X2, LayoutList, Target, Wallet } from "lucide-react";
 
 import AccountsPage from "./foundation/accounts/page";
 import CardsPage from "./foundation/cards/page";
 import CashflowPage from "./foundation/cashflow/page";
 import CategoriesPage from "./foundation/categories/page";
 import SchedulesPage from "./foundation/schedules/page";
+import GoalsPage from "./foundation/goals/page";
 
-export type RouteKey = "cashflow" | "accounts" | "cards" | "categories" | "schedules";
+export type RouteKey = "cashflow" | "accounts" | "cards" | "categories" | "schedules" | "goals";
 
 export interface RouteDef {
   label: string;
@@ -22,4 +23,5 @@ export const routes: Record<RouteKey, RouteDef> = {
   cards: { label: "Cartoes", shortLabel: "Cartoes", icon: <CreditCard className="h-4 w-4" />, render: () => <CardsPage /> },
   categories: { label: "Categorias", shortLabel: "Tags", icon: <Grid2X2 className="h-4 w-4" />, render: () => <CategoriesPage /> },
   schedules: { label: "Compromissos", shortLabel: "Comprom.", icon: <LayoutList className="h-4 w-4" />, render: () => <SchedulesPage /> },
+  goals: { label: "Metas", shortLabel: "Metas", icon: <Target className="h-4 w-4" />, render: () => <GoalsPage /> },
 };

--- a/src/components/foundation/goal-form.tsx
+++ b/src/components/foundation/goal-form.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+
+import { Button } from "../ui/button";
+
+export type GoalType = "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM";
+
+export interface GoalFormValues {
+  title: string;
+  description: string;
+  type: GoalType;
+  targetDate: string | null;
+}
+
+interface GoalFormProps {
+  onSubmit: (values: GoalFormValues) => void;
+  submitLabel?: string;
+  initialValues?: Partial<GoalFormValues>;
+}
+
+export function goalTypeLabel(type: GoalType) {
+  switch (type) {
+    case "FINANCIAL":
+      return "Financeira";
+    case "PERSONAL":
+      return "Pessoal";
+    case "FAMILY":
+      return "Familia";
+    case "DREAM":
+      return "Sonho";
+    default:
+      return type;
+  }
+}
+
+export function GoalForm({ onSubmit, submitLabel = "Salvar meta", initialValues }: GoalFormProps) {
+  const [title, setTitle] = useState(initialValues?.title ?? "");
+  const [description, setDescription] = useState(initialValues?.description ?? "");
+  const [type, setType] = useState<GoalType>(initialValues?.type ?? "FINANCIAL");
+  const [targetDate, setTargetDate] = useState(initialValues?.targetDate ?? "");
+
+  useEffect(() => {
+    setTitle(initialValues?.title ?? "");
+    setDescription(initialValues?.description ?? "");
+    setType(initialValues?.type ?? "FINANCIAL");
+    setTargetDate(initialValues?.targetDate ?? "");
+  }, [initialValues]);
+
+  return (
+    <form
+      className="grid gap-3"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit({
+          title: title.trim(),
+          description: description.trim(),
+          type,
+          targetDate: targetDate || null,
+        });
+      }}
+    >
+      <label>
+        Titulo
+        <input aria-label="Titulo da meta" value={title} onChange={(event) => setTitle(event.target.value)} required minLength={3} />
+      </label>
+
+      <label>
+        Descricao
+        <textarea
+          aria-label="Descricao da meta"
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          required
+          minLength={3}
+          rows={4}
+        />
+      </label>
+
+      <label>
+        Tipo
+        <select aria-label="Tipo da meta" value={type} onChange={(event) => setType(event.target.value as GoalType)}>
+          <option value="FINANCIAL">Financeira</option>
+          <option value="PERSONAL">Pessoal</option>
+          <option value="FAMILY">Familia</option>
+          <option value="DREAM">Sonho</option>
+        </select>
+      </label>
+
+      <label>
+        Data alvo
+        <input aria-label="Data alvo" type="date" value={targetDate} onChange={(event) => setTargetDate(event.target.value)} />
+      </label>
+
+      <Button type="submit" className="w-full">
+        {submitLabel}
+      </Button>
+    </form>
+  );
+}

--- a/src/server/vite-api.ts
+++ b/src/server/vite-api.ts
@@ -133,6 +133,22 @@ function normalizeName(value: string) {
   return value.trim().toLocaleLowerCase("pt-BR");
 }
 
+function isGoalType(value: unknown): value is "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM" {
+  return value === "FINANCIAL" || value === "PERSONAL" || value === "FAMILY" || value === "DREAM";
+}
+
+function normalizeGoalDate(raw: unknown): Date | null {
+  if (raw == null || raw === "") {
+    return null;
+  }
+  const normalized = typeof raw === "string" && raw.length === 10 ? `${raw}T00:00:00.000Z` : String(raw);
+  const parsed = new Date(normalized);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("GOAL_INVALID_INPUT");
+  }
+  return parsed;
+}
+
 function addMonths(monthKey: string, count: number) {
   const [year, month] = monthKey.split("-").map(Number);
   const date = new Date(Date.UTC(year, month - 1 + count, 1));
@@ -811,6 +827,102 @@ export function installViteApi(server: MiddlewareServer) {
           data: { householdId: authHouseholdId, name: body.name.trim(), normalized: normalizeName(body.name) },
         });
         sendJson(res, 200, created);
+        return;
+      }
+
+      if (req.method === "GET" && path === "/api/goals") {
+        const rows = await prisma.goal.findMany({
+          where: { householdId: authHouseholdId },
+          orderBy: { createdAt: "desc" },
+        });
+        sendJson(
+          res,
+          200,
+          rows.map((goal) => ({
+            ...goal,
+            targetDate: goal.targetDate ? goal.targetDate.toISOString() : null,
+            createdAt: goal.createdAt.toISOString(),
+            updatedAt: goal.updatedAt.toISOString(),
+          })),
+        );
+        return;
+      }
+
+      if (req.method === "POST" && path === "/api/goals") {
+        const body = await readJsonBody(req);
+        const title = String(body.title ?? "").trim();
+        const description = String(body.description ?? "").trim();
+        if (title.length < 3 || title.length > 120 || description.length < 3 || description.length > 1000 || !isGoalType(body.type)) {
+          sendJson(res, 400, { message: "GOAL_INVALID_INPUT" });
+          return;
+        }
+
+        let targetDate: Date | null = null;
+        try {
+          targetDate = normalizeGoalDate(body.targetDate);
+        } catch {
+          sendJson(res, 400, { message: "GOAL_INVALID_INPUT" });
+          return;
+        }
+
+        const created = await prisma.goal.create({
+          data: {
+            householdId: authHouseholdId,
+            title,
+            description,
+            type: body.type,
+            targetDate,
+          },
+        });
+
+        sendJson(res, 200, {
+          ...created,
+          targetDate: created.targetDate ? created.targetDate.toISOString() : null,
+          createdAt: created.createdAt.toISOString(),
+          updatedAt: created.updatedAt.toISOString(),
+        });
+        return;
+      }
+
+      if (req.method === "POST" && path === "/api/goals/edit") {
+        const body = await readJsonBody(req);
+        const existing = await prisma.goal.findUnique({ where: { id: body.id } });
+        if (!existing || existing.householdId !== authHouseholdId) {
+          sendJson(res, 404, { message: "GOAL_NOT_FOUND" });
+          return;
+        }
+
+        const title = String(body.title ?? "").trim();
+        const description = String(body.description ?? "").trim();
+        if (title.length < 3 || title.length > 120 || description.length < 3 || description.length > 1000 || !isGoalType(body.type)) {
+          sendJson(res, 400, { message: "GOAL_INVALID_INPUT" });
+          return;
+        }
+
+        let targetDate: Date | null = null;
+        try {
+          targetDate = normalizeGoalDate(body.targetDate);
+        } catch {
+          sendJson(res, 400, { message: "GOAL_INVALID_INPUT" });
+          return;
+        }
+
+        const updated = await prisma.goal.update({
+          where: { id: body.id },
+          data: {
+            title,
+            description,
+            type: body.type,
+            targetDate,
+          },
+        });
+
+        sendJson(res, 200, {
+          ...updated,
+          targetDate: updated.targetDate ? updated.targetDate.toISOString() : null,
+          createdAt: updated.createdAt.toISOString(),
+          updatedAt: updated.updatedAt.toISOString(),
+        });
         return;
       }
 


### PR DESCRIPTION
## Summary
Implements issue #5 with the updated scope requested in comments: Metas includes `type` and `targetDate` in this phase.

## What was implemented

### Data model (Prisma)
- Added `GoalType` enum:
  - `FINANCIAL`, `PERSONAL`, `FAMILY`, `DREAM`
- Added `Goal` model with:
  - `id`, `householdId`, `title`, `description`, `type`, `targetDate`, `createdAt`, `updatedAt`
- Added indexes for:
  - `(householdId, createdAt)`
  - `(householdId, type)`
  - `(householdId, targetDate)`
- Applied in both schemas:
  - `prisma/schema.prisma` (sqlite)
  - `prisma/schema.prod.prisma` (postgres)

### API (`src/server/vite-api.ts`)
- Added validation helpers:
  - `isGoalType`
  - `normalizeGoalDate`
- Added endpoints:
  - `GET /api/goals`
  - `POST /api/goals`
  - `POST /api/goals/edit`
- Business rules included:
  - Auth/session required
  - Household isolation by `authHouseholdId`
  - Input validation for title/description/type/date
  - `GOAL_NOT_FOUND` for cross-household/nonexistent edits

### Runtime integration (`src/app/foundation/runtime.ts`)
- Added `GoalsControllerContract`
- Exposed `goalsController` in runtime exports
- Added API runtime bindings to new endpoints
- Added local test runtime in-memory implementation (create/list/update)

### UI/Navigation
- Added new route in `src/app/routes.tsx`:
  - `goals` => label `Metas`
- Added page:
  - `src/app/foundation/goals/page.tsx`
  - list + create + edit flow
- Added reusable form:
  - `src/components/foundation/goal-form.tsx`
  - fields: title, description, type, targetDate
  - PT-BR labels for enum presentation

## Validation performed
- `npm run build` ✅ (successful production build)

## Notes
- PR base is `master` as requested.

Closes #5
