### PR TITLE
feat: metric types for goals + progress bar

### DIFF
--- a/prisma/migrations/20260322015500_goal_metric_types/migration.sql
+++ b/prisma/migrations/20260322015500_goal_metric_types/migration.sql
@@ -1,0 +1,4 @@
+-- Goal metrics (percentage | quantity | occurrence)
+ALTER TABLE "Goal" ADD COLUMN "metricType" TEXT NOT NULL DEFAULT 'PERCENTAGE';
+ALTER TABLE "Goal" ADD COLUMN "metricValue" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "Goal" ADD COLUMN "metricTarget" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,12 @@ enum GoalType {
   DREAM
 }
 
+enum GoalMetricType {
+  PERCENTAGE
+  QUANTITY
+  OCCURRENCE
+}
+
 model Account {
   id             String        @id @default(cuid())
   householdId    String
@@ -174,14 +180,17 @@ model ScheduledInstance {
 
 
 model Goal {
-  id          String    @id @default(cuid())
+  id          String         @id @default(cuid())
   householdId String
   title       String
   description String
   type        GoalType
   targetDate  DateTime?
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  metricType  GoalMetricType @default(PERCENTAGE)
+  metricValue Int            @default(0)
+  metricTarget Int?
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
 
   @@index([householdId, createdAt])
   @@index([householdId, type])

--- a/prisma/schema.prod.prisma
+++ b/prisma/schema.prod.prisma
@@ -34,6 +34,12 @@ enum GoalType {
   DREAM
 }
 
+enum GoalMetricType {
+  PERCENTAGE
+  QUANTITY
+  OCCURRENCE
+}
+
 model Account {
   id             String        @id @default(cuid())
   householdId    String
@@ -174,14 +180,17 @@ model ScheduledInstance {
 
 
 model Goal {
-  id          String    @id @default(cuid())
-  householdId String
-  title       String
-  description String
-  type        GoalType
-  targetDate  DateTime?
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  id           String         @id @default(cuid())
+  householdId  String
+  title        String
+  description  String
+  type         GoalType
+  targetDate   DateTime?
+  metricType   GoalMetricType @default(PERCENTAGE)
+  metricValue  Int            @default(0)
+  metricTarget Int?
+  createdAt    DateTime       @default(now())
+  updatedAt    DateTime       @updatedAt
 
   @@index([householdId, createdAt])
   @@index([householdId, type])

--- a/src/app/foundation/goals/page.tsx
+++ b/src/app/foundation/goals/page.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 
-import { GoalForm, goalTypeLabel, type GoalType } from "../../../components/foundation/goal-form";
+import { GoalForm, goalTypeLabel, metricTypeLabel, type GoalMetricType, type GoalType } from "../../../components/foundation/goal-form";
 import { Badge } from "../../../components/ui/badge";
 import { Button } from "../../../components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../../../components/ui/card";
@@ -13,6 +13,32 @@ function formatDate(value: string | null) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "Sem data alvo";
   return date.toLocaleDateString("pt-BR", { timeZone: "UTC" });
+}
+
+function clampProgress(value: number) {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function formatMetric(goal: {
+  metricType: GoalMetricType;
+  metricValue: number;
+  metricTarget: number | null;
+  progressPercent: number;
+}) {
+  if (goal.metricType === "PERCENTAGE") {
+    return `${clampProgress(goal.metricValue)}%`;
+  }
+
+  if (goal.metricType === "QUANTITY") {
+    return `${goal.metricValue} / ${goal.metricTarget ?? "-"}`;
+  }
+
+  if (goal.metricTarget != null) {
+    return `${goal.metricValue} / ${goal.metricTarget} ocorrencias`;
+  }
+
+  return `${goal.metricValue} ocorrencias`;
 }
 
 export default function GoalsPage() {
@@ -44,30 +70,43 @@ export default function GoalsPage() {
         <CardContent>
           {goals.length === 0 ? <p className="text-sm text-slate-500 dark:text-slate-300">Nenhuma meta cadastrada ainda.</p> : null}
           <ul className="space-y-3">
-            {goals.map((goal) => (
-              <li key={goal.id} className="space-y-2 rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-slate-800 dark:bg-slate-950/70">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="font-semibold text-slate-900 dark:text-slate-100">{goal.title}</p>
-                    <p className="text-sm text-slate-600 dark:text-slate-300">{goal.description}</p>
+            {goals.map((goal) => {
+              const progress = clampProgress(goal.progressPercent);
+              return (
+                <li key={goal.id} className="space-y-2 rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-slate-800 dark:bg-slate-950/70">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="font-semibold text-slate-900 dark:text-slate-100">{goal.title}</p>
+                      <p className="text-sm text-slate-600 dark:text-slate-300">{goal.description}</p>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => {
+                        setEditingGoalId(goal.id);
+                        setEditModalOpen(true);
+                      }}
+                    >
+                      Editar
+                    </Button>
                   </div>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => {
-                      setEditingGoalId(goal.id);
-                      setEditModalOpen(true);
-                    }}
-                  >
-                    Editar
-                  </Button>
-                </div>
-                <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-300">
-                  <Badge variant="secondary">{goalTypeLabel(goal.type as GoalType)}</Badge>
-                  <span>{formatDate(goal.targetDate)}</span>
-                </div>
-              </li>
-            ))}
+                  <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-300">
+                    <Badge variant="secondary">{goalTypeLabel(goal.type as GoalType)}</Badge>
+                    <Badge variant="outline">{metricTypeLabel(goal.metricType as GoalMetricType)}</Badge>
+                    <span>{formatDate(goal.targetDate)}</span>
+                  </div>
+                  <div className="space-y-1">
+                    <div className="flex items-center justify-between text-xs text-slate-600 dark:text-slate-300">
+                      <span>{formatMetric(goal)}</span>
+                      <span>{progress}%</span>
+                    </div>
+                    <div className="h-2 w-full overflow-hidden rounded-full bg-slate-200 dark:bg-slate-800" aria-label={`Progresso da meta: ${progress}%`}>
+                      <div className="h-full rounded-full bg-blue-600 transition-all" style={{ width: `${progress}%` }} />
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
           </ul>
         </CardContent>
       </Card>
@@ -76,7 +115,7 @@ export default function GoalsPage() {
         <SheetContent className="inset-y-auto left-1/2 top-1/2 h-auto max-h-[88vh] w-[94%] max-w-xl -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-3xl border-r-0">
           <SheetHeader>
             <SheetTitle>Nova meta</SheetTitle>
-            <SheetDescription>Cadastre titulo, descricao, tipo e data alvo.</SheetDescription>
+            <SheetDescription>Cadastre titulo, descricao, tipo, metrica e data alvo.</SheetDescription>
           </SheetHeader>
           <div className="mt-4">
             <GoalForm
@@ -119,6 +158,9 @@ export default function GoalsPage() {
                   description: editingGoal.description,
                   type: editingGoal.type,
                   targetDate: editingGoal.targetDate ? editingGoal.targetDate.slice(0, 10) : "",
+                  metricType: editingGoal.metricType,
+                  metricValue: editingGoal.metricValue,
+                  metricTarget: editingGoal.metricTarget,
                 }}
                 onSubmit={(values) => {
                   try {

--- a/src/app/foundation/runtime.ts
+++ b/src/app/foundation/runtime.ts
@@ -29,6 +29,21 @@ type MethodReturn<T> = T extends (...args: any[]) => infer R ? R : never;
 type AccountsControllerContract = Pick<AccountsController, "createAccount" | "updateAccountGoal" | "listAccounts" | "getConsolidatedBalance">;
 type CardsControllerContract = Pick<CardsController, "createCard" | "listCards" | "updateCard" | "deleteCard">;
 type CategoriesControllerContract = Pick<CategoriesController, "createCategory" | "listCategories">;
+type GoalMetricType = "PERCENTAGE" | "QUANTITY" | "OCCURRENCE";
+type GoalDto = {
+  id: string;
+  householdId: string;
+  title: string;
+  description: string;
+  type: "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM";
+  targetDate: string | null;
+  metricType: GoalMetricType;
+  metricValue: number;
+  metricTarget: number | null;
+  progressPercent: number;
+  createdAt: string;
+  updatedAt: string;
+};
 type GoalsControllerContract = {
   createGoal: (input: {
     householdId: string;
@@ -36,26 +51,11 @@ type GoalsControllerContract = {
     description: string;
     type: "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM";
     targetDate?: string | null;
-  }) => {
-    id: string;
-    householdId: string;
-    title: string;
-    description: string;
-    type: "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM";
-    targetDate: string | null;
-    createdAt: string;
-    updatedAt: string;
-  };
-  listGoals: (householdId: string) => Array<{
-    id: string;
-    householdId: string;
-    title: string;
-    description: string;
-    type: "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM";
-    targetDate: string | null;
-    createdAt: string;
-    updatedAt: string;
-  }>;
+    metricType: GoalMetricType;
+    metricValue: number;
+    metricTarget?: number | null;
+  }) => GoalDto;
+  listGoals: (householdId: string) => GoalDto[];
   updateGoal: (input: {
     householdId: string;
     id: string;
@@ -63,16 +63,10 @@ type GoalsControllerContract = {
     description: string;
     type: "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM";
     targetDate?: string | null;
-  }) => {
-    id: string;
-    householdId: string;
-    title: string;
-    description: string;
-    type: "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM";
-    targetDate: string | null;
-    createdAt: string;
-    updatedAt: string;
-  };
+    metricType: GoalMetricType;
+    metricValue: number;
+    metricTarget?: number | null;
+  }) => GoalDto;
 };
 type TransactionsControllerContract = Pick<
   TransactionsController,
@@ -141,6 +135,18 @@ function handleUnauthorized() {
   if (typeof window !== "undefined" && window.location.pathname !== "/") {
     window.location.assign("/");
   }
+}
+
+function calculateGoalProgress(input: { metricType: GoalMetricType; metricValue: number; metricTarget: number | null }) {
+  if (input.metricType === "PERCENTAGE") {
+    return Math.max(0, Math.min(100, Math.round(input.metricValue)));
+  }
+
+  if (input.metricTarget == null || input.metricTarget <= 0) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(100, Math.round((input.metricValue / input.metricTarget) * 100)));
 }
 
 function requestSync<T>(method: "GET" | "POST", url: string, payload?: unknown): T {
@@ -213,16 +219,7 @@ function createLocalRuntime(): Runtime {
     ),
   );
 
-  const localGoalsStore: Array<{
-    id: string;
-    householdId: string;
-    title: string;
-    description: string;
-    type: "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM";
-    targetDate: string | null;
-    createdAt: string;
-    updatedAt: string;
-  }> = [];
+  const localGoalsStore: GoalDto[] = [];
 
   return {
     accountsController,
@@ -246,13 +243,21 @@ function createLocalRuntime(): Runtime {
     goalsController: {
       createGoal: (input) => {
         const now = new Date().toISOString();
-        const record = {
+        const record: GoalDto = {
           id: `goal-${Date.now()}`,
           householdId: input.householdId,
           title: input.title,
           description: input.description,
           type: input.type,
           targetDate: input.targetDate ?? null,
+          metricType: input.metricType,
+          metricValue: input.metricValue,
+          metricTarget: input.metricType === "PERCENTAGE" ? null : (input.metricTarget ?? null),
+          progressPercent: calculateGoalProgress({
+            metricType: input.metricType,
+            metricValue: input.metricValue,
+            metricTarget: input.metricType === "PERCENTAGE" ? null : (input.metricTarget ?? null),
+          }),
           createdAt: now,
           updatedAt: now,
         };
@@ -272,6 +277,14 @@ function createLocalRuntime(): Runtime {
         found.description = input.description;
         found.type = input.type;
         found.targetDate = input.targetDate ?? null;
+        found.metricType = input.metricType;
+        found.metricValue = input.metricValue;
+        found.metricTarget = input.metricType === "PERCENTAGE" ? null : (input.metricTarget ?? null);
+        found.progressPercent = calculateGoalProgress({
+          metricType: found.metricType,
+          metricValue: found.metricValue,
+          metricTarget: found.metricTarget,
+        });
         found.updatedAt = new Date().toISOString();
         return found;
       },
@@ -417,6 +430,9 @@ function createApiRuntime(): Runtime {
           description: input.description,
           type: input.type,
           targetDate: input.targetDate ?? null,
+          metricType: input.metricType,
+          metricValue: input.metricValue,
+          metricTarget: input.metricTarget ?? null,
         }),
       listGoals: (_householdId: string): GoalsListOutput => requestSync<GoalsListOutput>("GET", "/api/goals"),
       updateGoal: (input: GoalsUpdateInput): GoalsUpdateOutput =>
@@ -426,6 +442,9 @@ function createApiRuntime(): Runtime {
           description: input.description,
           type: input.type,
           targetDate: input.targetDate ?? null,
+          metricType: input.metricType,
+          metricValue: input.metricValue,
+          metricTarget: input.metricTarget ?? null,
         }),
     },
     transactionsController: {

--- a/src/components/foundation/goal-form.tsx
+++ b/src/components/foundation/goal-form.tsx
@@ -3,12 +3,16 @@ import { useEffect, useState } from "react";
 import { Button } from "../ui/button";
 
 export type GoalType = "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM";
+export type GoalMetricType = "PERCENTAGE" | "QUANTITY" | "OCCURRENCE";
 
 export interface GoalFormValues {
   title: string;
   description: string;
   type: GoalType;
   targetDate: string | null;
+  metricType: GoalMetricType;
+  metricValue: number;
+  metricTarget: number | null;
 }
 
 interface GoalFormProps {
@@ -32,17 +36,47 @@ export function goalTypeLabel(type: GoalType) {
   }
 }
 
+export function metricTypeLabel(type: GoalMetricType) {
+  switch (type) {
+    case "PERCENTAGE":
+      return "Porcentagem";
+    case "QUANTITY":
+      return "Quantidade";
+    case "OCCURRENCE":
+      return "Ocorrencias";
+    default:
+      return type;
+  }
+}
+
+function parseOptionalPositiveInteger(value: string) {
+  if (!value.trim()) return null;
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
 export function GoalForm({ onSubmit, submitLabel = "Salvar meta", initialValues }: GoalFormProps) {
   const [title, setTitle] = useState(initialValues?.title ?? "");
   const [description, setDescription] = useState(initialValues?.description ?? "");
   const [type, setType] = useState<GoalType>(initialValues?.type ?? "FINANCIAL");
   const [targetDate, setTargetDate] = useState(initialValues?.targetDate ?? "");
+  const [metricType, setMetricType] = useState<GoalMetricType>(initialValues?.metricType ?? "PERCENTAGE");
+  const [metricValue, setMetricValue] = useState(String(initialValues?.metricValue ?? 0));
+  const [metricTarget, setMetricTarget] = useState(
+    initialValues?.metricTarget == null ? "" : String(initialValues.metricTarget),
+  );
+  const [metricError, setMetricError] = useState<string | null>(null);
 
   useEffect(() => {
     setTitle(initialValues?.title ?? "");
     setDescription(initialValues?.description ?? "");
     setType(initialValues?.type ?? "FINANCIAL");
     setTargetDate(initialValues?.targetDate ?? "");
+    setMetricType(initialValues?.metricType ?? "PERCENTAGE");
+    setMetricValue(String(initialValues?.metricValue ?? 0));
+    setMetricTarget(initialValues?.metricTarget == null ? "" : String(initialValues.metricTarget));
+    setMetricError(null);
   }, [initialValues]);
 
   return (
@@ -50,11 +84,39 @@ export function GoalForm({ onSubmit, submitLabel = "Salvar meta", initialValues 
       className="grid gap-3"
       onSubmit={(event) => {
         event.preventDefault();
+
+        const parsedMetricValue = Number.parseInt(metricValue, 10);
+        if (Number.isNaN(parsedMetricValue) || parsedMetricValue < 0) {
+          setMetricError("Informe um valor inteiro maior ou igual a 0.");
+          return;
+        }
+
+        if (metricType === "PERCENTAGE" && parsedMetricValue > 100) {
+          setMetricError("Para porcentagem, o valor deve estar entre 0 e 100.");
+          return;
+        }
+
+        const parsedMetricTarget = parseOptionalPositiveInteger(metricTarget);
+
+        if (metricType === "QUANTITY" && parsedMetricTarget == null) {
+          setMetricError("Para quantidade, informe uma meta alvo maior que 0.");
+          return;
+        }
+
+        if ((metricType === "OCCURRENCE" || metricType === "PERCENTAGE") && metricTarget.trim() && parsedMetricTarget == null) {
+          setMetricError("Quando informado, o alvo deve ser maior que 0.");
+          return;
+        }
+
+        setMetricError(null);
         onSubmit({
           title: title.trim(),
           description: description.trim(),
           type,
           targetDate: targetDate || null,
+          metricType,
+          metricValue: parsedMetricValue,
+          metricTarget: metricType === "PERCENTAGE" ? null : parsedMetricTarget,
         });
       }}
     >
@@ -84,6 +146,62 @@ export function GoalForm({ onSubmit, submitLabel = "Salvar meta", initialValues 
           <option value="DREAM">Sonho</option>
         </select>
       </label>
+
+      <label>
+        Tipo de metrica
+        <select
+          aria-label="Tipo de metrica"
+          value={metricType}
+          onChange={(event) => {
+            const nextType = event.target.value as GoalMetricType;
+            setMetricType(nextType);
+            setMetricError(null);
+            if (nextType === "PERCENTAGE") {
+              setMetricTarget("");
+            }
+          }}
+        >
+          <option value="PERCENTAGE">Porcentagem</option>
+          <option value="QUANTITY">Quantidade</option>
+          <option value="OCCURRENCE">Ocorrencias</option>
+        </select>
+      </label>
+
+      <label>
+        Valor atual
+        <input
+          aria-label="Valor atual"
+          type="number"
+          min={0}
+          step={1}
+          value={metricValue}
+          onChange={(event) => {
+            setMetricValue(event.target.value);
+            setMetricError(null);
+          }}
+          required
+        />
+      </label>
+
+      {metricType !== "PERCENTAGE" ? (
+        <label>
+          Meta alvo {metricType === "QUANTITY" ? "*" : "(opcional)"}
+          <input
+            aria-label="Meta alvo"
+            type="number"
+            min={1}
+            step={1}
+            value={metricTarget}
+            onChange={(event) => {
+              setMetricTarget(event.target.value);
+              setMetricError(null);
+            }}
+            required={metricType === "QUANTITY"}
+          />
+        </label>
+      ) : null}
+
+      {metricError ? <p className="text-sm text-rose-600 dark:text-rose-300">{metricError}</p> : null}
 
       <label>
         Data alvo

--- a/src/server/vite-api.ts
+++ b/src/server/vite-api.ts
@@ -137,6 +137,10 @@ function isGoalType(value: unknown): value is "FINANCIAL" | "PERSONAL" | "FAMILY
   return value === "FINANCIAL" || value === "PERSONAL" || value === "FAMILY" || value === "DREAM";
 }
 
+function isGoalMetricType(value: unknown): value is "PERCENTAGE" | "QUANTITY" | "OCCURRENCE" {
+  return value === "PERCENTAGE" || value === "QUANTITY" || value === "OCCURRENCE";
+}
+
 function normalizeGoalDate(raw: unknown): Date | null {
   if (raw == null || raw === "") {
     return null;
@@ -147,6 +151,71 @@ function normalizeGoalDate(raw: unknown): Date | null {
     throw new Error("GOAL_INVALID_INPUT");
   }
   return parsed;
+}
+
+function normalizeGoalMetricInput(input: { metricType: unknown; metricValue: unknown; metricTarget: unknown }) {
+  if (!isGoalMetricType(input.metricType)) {
+    throw new Error("GOAL_INVALID_INPUT");
+  }
+
+  const metricValue = Number(input.metricValue);
+  if (!Number.isInteger(metricValue) || metricValue < 0) {
+    throw new Error("GOAL_INVALID_INPUT");
+  }
+
+  if (input.metricType === "PERCENTAGE") {
+    if (metricValue > 100) {
+      throw new Error("GOAL_INVALID_INPUT");
+    }
+    return { metricType: input.metricType, metricValue, metricTarget: null as number | null };
+  }
+
+  if (input.metricType === "QUANTITY") {
+    const metricTarget = Number(input.metricTarget);
+    if (!Number.isInteger(metricTarget) || metricTarget <= 0) {
+      throw new Error("GOAL_INVALID_INPUT");
+    }
+    return { metricType: input.metricType, metricValue, metricTarget };
+  }
+
+  if (input.metricTarget == null || input.metricTarget === "") {
+    return { metricType: input.metricType, metricValue, metricTarget: null as number | null };
+  }
+
+  const metricTarget = Number(input.metricTarget);
+  if (!Number.isInteger(metricTarget) || metricTarget <= 0) {
+    throw new Error("GOAL_INVALID_INPUT");
+  }
+  return { metricType: input.metricType, metricValue, metricTarget };
+}
+
+function toGoalDto(goal: {
+  id: string;
+  householdId: string;
+  title: string;
+  description: string;
+  type: "FINANCIAL" | "PERSONAL" | "FAMILY" | "DREAM";
+  targetDate: Date | null;
+  metricType: "PERCENTAGE" | "QUANTITY" | "OCCURRENCE";
+  metricValue: number;
+  metricTarget: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+}) {
+  const progressPercent =
+    goal.metricType === "PERCENTAGE"
+      ? Math.max(0, Math.min(100, goal.metricValue))
+      : goal.metricTarget && goal.metricTarget > 0
+        ? Math.max(0, Math.min(100, Math.round((goal.metricValue / goal.metricTarget) * 100)))
+        : 0;
+
+  return {
+    ...goal,
+    progressPercent,
+    targetDate: goal.targetDate ? goal.targetDate.toISOString() : null,
+    createdAt: goal.createdAt.toISOString(),
+    updatedAt: goal.updatedAt.toISOString(),
+  };
 }
 
 function addMonths(monthKey: string, count: number) {
@@ -835,16 +904,7 @@ export function installViteApi(server: MiddlewareServer) {
           where: { householdId: authHouseholdId },
           orderBy: { createdAt: "desc" },
         });
-        sendJson(
-          res,
-          200,
-          rows.map((goal) => ({
-            ...goal,
-            targetDate: goal.targetDate ? goal.targetDate.toISOString() : null,
-            createdAt: goal.createdAt.toISOString(),
-            updatedAt: goal.updatedAt.toISOString(),
-          })),
-        );
+        sendJson(res, 200, rows.map(toGoalDto));
         return;
       }
 
@@ -858,8 +918,14 @@ export function installViteApi(server: MiddlewareServer) {
         }
 
         let targetDate: Date | null = null;
+        let metricInput: { metricType: "PERCENTAGE" | "QUANTITY" | "OCCURRENCE"; metricValue: number; metricTarget: number | null };
         try {
           targetDate = normalizeGoalDate(body.targetDate);
+          metricInput = normalizeGoalMetricInput({
+            metricType: body.metricType,
+            metricValue: body.metricValue,
+            metricTarget: body.metricTarget,
+          });
         } catch {
           sendJson(res, 400, { message: "GOAL_INVALID_INPUT" });
           return;
@@ -872,15 +938,13 @@ export function installViteApi(server: MiddlewareServer) {
             description,
             type: body.type,
             targetDate,
+            metricType: metricInput.metricType,
+            metricValue: metricInput.metricValue,
+            metricTarget: metricInput.metricTarget,
           },
         });
 
-        sendJson(res, 200, {
-          ...created,
-          targetDate: created.targetDate ? created.targetDate.toISOString() : null,
-          createdAt: created.createdAt.toISOString(),
-          updatedAt: created.updatedAt.toISOString(),
-        });
+        sendJson(res, 200, toGoalDto(created));
         return;
       }
 
@@ -900,8 +964,14 @@ export function installViteApi(server: MiddlewareServer) {
         }
 
         let targetDate: Date | null = null;
+        let metricInput: { metricType: "PERCENTAGE" | "QUANTITY" | "OCCURRENCE"; metricValue: number; metricTarget: number | null };
         try {
           targetDate = normalizeGoalDate(body.targetDate);
+          metricInput = normalizeGoalMetricInput({
+            metricType: body.metricType,
+            metricValue: body.metricValue,
+            metricTarget: body.metricTarget,
+          });
         } catch {
           sendJson(res, 400, { message: "GOAL_INVALID_INPUT" });
           return;
@@ -914,15 +984,13 @@ export function installViteApi(server: MiddlewareServer) {
             description,
             type: body.type,
             targetDate,
+            metricType: metricInput.metricType,
+            metricValue: metricInput.metricValue,
+            metricTarget: metricInput.metricTarget,
           },
         });
 
-        sendJson(res, 200, {
-          ...updated,
-          targetDate: updated.targetDate ? updated.targetDate.toISOString() : null,
-          createdAt: updated.createdAt.toISOString(),
-          updatedAt: updated.updatedAt.toISOString(),
-        });
+        sendJson(res, 200, toGoalDto(updated));
         return;
       }
 


### PR DESCRIPTION
Summary\n- add goal metric model (PERCENTAGE, QUANTITY, OCCURRENCE) in Prisma schema and migration\n- extend goals API create/edit/list to persist metric fields and return computed progressPercent\n- update foundation runtime contract/local runtime to support new goal metric fields\n- update goal form with dynamic metric inputs + validations\n- update goals list UI to show metric context and progress bar percentage\n\nValidation\n- npx prisma generate --schema prisma/schema.prisma\n- npm run lint (fails due to pre-existing repo-wide TypeScript issues unrelated to this PR)\n